### PR TITLE
灰度图转换出错

### DIFF
--- a/01-图像二值化.py
+++ b/01-图像二值化.py
@@ -3,7 +3,7 @@ import numpy as np
 
 # 全局阈值
 def threshold_demo(image):
-    gray = cv.cvtColor(image,cv.COLOR_RGB2GRAY) #把输入图像灰度化
+    gray = cv.cvtColor(image,cv.COLOR_BGR2GRAY) #把输入图像灰度化
     #直接阈值化是对输入的单通道矩阵逐像素进行阈值化分割。
     ret,binary = cv.threshold(gray,0,255,cv.THRESH_BINARY|cv.THRESH_TRIANGLE)
     print("threshold value %s"%ret)
@@ -12,14 +12,14 @@ def threshold_demo(image):
 
 # 局部阈值
 def local_threshold(image):
-    gray = cv.cvtColor(image,cv.COLOR_RGB2GRAY)
+    gray = cv.cvtColor(image,cv.COLOR_BGR2GRAY)
     binary = cv.adaptiveThreshold(gray,255,cv.ADAPTIVE_THRESH_GAUSSIAN_C,cv.THRESH_BINARY,25,10)
     cv.namedWindow("binary1", cv.WINDOW_NORMAL)
     cv.imshow("binary1", binary)
 
 # 用户自己计算阈值
 def custom_threshold(image):
-    gray = cv.cvtColor(image, cv.COLOR_RGB2GRAY)
+    gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
     h,w = gray.shape[:2]
     m = np.reshape(gray,[1,w*h])
     mean = m.sum()/(w*h)


### PR DESCRIPTION
opencv读入的是BGR格式图像，所以应该使用BGR2GRAY